### PR TITLE
Update redblack.tex

### DIFF
--- a/ja/redblack.tex
+++ b/ja/redblack.tex
@@ -378,8 +378,7 @@ Case 1：#u#の兄弟#v#が赤ノードの場合。
 \codeimport{ods/RedBlackTree.removeFixupCase1(u)}
 
 \noindent
-Case 2：#u#の兄弟#v#が黒ノードの場合。
-このとき、#u#は親#w#の左の子である。
+Case 2：#u#の兄弟が黒ノードで、#u#が親#w#の左の子である場合。
 #pullBlack(w)#を呼ぶと、#u#は黒ノードに、#v#は赤ノードになり、#w#は黒もしくはダブルブラックになる。
 このとき#w#は左傾性を満たしておらず、#flipLeft(w)#を呼んでこれを解決する。
 


### PR DESCRIPTION
原文の「Case 2: $ \ensuremath{\ensuremath{\mathit{u}}}$'s sibling, $ \ensuremath{\ensuremath{\mathit{v}}}$, is black, and $ \ensuremath{\ensuremath{\mathit{u}}}$ is the left child of its parent, $ \ensuremath{\ensuremath{\mathit{w}}}$.」と訳文の「Case 3：#u#の兄弟が黒ノードで、#u#が右の子である場合。」との整合性からこちらのほうが適切かと思いました。